### PR TITLE
Add Go Mobile as the backbone of Lantern for Android

### DIFF
--- a/JoseNieto-GoMobileAsTheBackboneOfLanternForAndroid/README.md
+++ b/JoseNieto-GoMobileAsTheBackboneOfLanternForAndroid/README.md
@@ -1,0 +1,8 @@
+# Go Mobile as the backend of Lantern for Android
+
+A talk given at GopherCon 2016. This copy does not include video demos.
+
+## Contact
+
+* [@xiam](https://twitter.com/xiam)
+* jose @ menteslibres.org


### PR DESCRIPTION
This PR adds a PDF copy of the "Go Mobile as the backbone of Lantern for Android" talk.

Thanks!
